### PR TITLE
Fix skipping tests, add debug script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ]
   },
   "scripts": {
+    "debug": "web-test-runner --watch",
     "lint": "npm-run-all --parallel lint:*",
     "lint:css": "stylelint packages/**/src/*.js packages/**/theme/**/*-styles.js",
     "lint:js": "eslint *.js scripts packages",

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -98,7 +98,7 @@ describe('vaadin-combo-box-light', () => {
       expect(comboBox.opened).to.be.true;
     });
 
-    const isSafari = /Safari/i.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     (isSafari ? it.skip : it)('should toggle on input click on touch devices', (done) => {
       downAndUp(
         ironInput,

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -276,7 +276,7 @@ describe('keyboard', () => {
       expect(comboBox.inputElement.value).to.eql('baz');
     });
 
-    const isSafari = /Safari/i.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     (isSafari ? it.skip : it)('should select the input field text when navigating down', async () => {
       arrowDown();
       await aTimeout(1);

--- a/packages/vaadin-context-menu/test/device-detector.test.js
+++ b/packages/vaadin-context-menu/test/device-detector.test.js
@@ -14,7 +14,7 @@ describe('device detector', () => {
     expect(detector.wide).to.eql(!isIOS);
   });
 
-  const isSafari = /Safari/i.test(navigator.userAgent);
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   (isSafari ? it.skip : it)('should detect touch support', () => {
     expect(detector.touch).to.eql(isIOS);
   });

--- a/packages/vaadin-context-menu/test/integration.test.js
+++ b/packages/vaadin-context-menu/test/integration.test.js
@@ -38,7 +38,7 @@ describe('integration', () => {
     expect(menu.opened).to.eql(true);
   });
 
-  const isSafari = /Safari/i.test(navigator.userAgent);
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   (isIOS || isSafari ? it.skip : it)('should open context menu below button', async () => {
     makeSoloTouchEvent('click', { y: 0, x: 0 }, button);
     await aTimeout(100);

--- a/packages/vaadin-menu-bar/test/sub-menu.test.js
+++ b/packages/vaadin-menu-bar/test/sub-menu.test.js
@@ -654,7 +654,7 @@ describe('touch', () => {
     }
   });
 
-  const isSafari = /Safari/i.test(navigator.userAgent);
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   (isSafari ? it.skip : it)('should close submenu on mobile when selecting an item in the nested one', async () => {
     arrowDown(buttons[0]);
     await onceOpened(subMenu);

--- a/packages/vaadin-radio-button/test/radio-button.test.js
+++ b/packages/vaadin-radio-button/test/radio-button.test.js
@@ -96,7 +96,7 @@ describe('radio-button', () => {
       expect(radio.checked).to.be.true;
     });
 
-    const isSafari = /Safari/i.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     (isSafari ? it.skip : it)('should set checked on touchend', () => {
       touchstart(radio);
       touchend(radio);
@@ -126,7 +126,7 @@ describe('radio-button', () => {
       expect(radio.checked).to.be.false;
     });
 
-    const isSafari = /Safari/i.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     (isSafari ? it.skip : it)('should not set checked on touchend when disabled', () => {
       touchstart(radio);
       touchend(radio);
@@ -213,7 +213,7 @@ describe('radio-button', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    const isSafari = /Safari/i.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     (isSafari ? it.skip : it)('should fire on touchend', () => {
       touchstart(radio);
       touchend(radio);

--- a/packages/vaadin-rich-text-editor/test/basic.test.js
+++ b/packages/vaadin-rich-text-editor/test/basic.test.js
@@ -41,7 +41,7 @@ describe('rich text editor', () => {
 
       // FIXME: flaky tests in GitHub Actions only in Firefox (passing locally).
       ['bold', 'italic', 'underline', 'strike', 'blockquote', 'code-block'].forEach((fmt) => {
-        const isSafari = /Safari/i.test(navigator.userAgent);
+        const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
         (isFirefox || isSafari ? it.skip : it)(`should apply ${fmt} formatting to the selected text on click`, () => {
           btn = getButton(fmt);
           btn.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));

--- a/packages/vaadin-text-field/test/text-area.test.js
+++ b/packages/vaadin-text-field/test/text-area.test.js
@@ -255,7 +255,7 @@ import '../vaadin-text-area.js';
         expect(textArea.clientHeight).to.be.below(height);
       });
 
-      const isSafari = /Safari/i.test(navigator.userAgent);
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
       (isSafari ? it.skip : it)('should not change height', () => {
         textArea.style.maxHeight = '100px';
         textArea.value = Array(400).join('400');

--- a/scripts/updateTests.js
+++ b/scripts/updateTests.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 const replace = require('replace-in-file');
 
+const chrome = 'window.chrome || /HeadlessChrome/.test(navigator.userAgent)';
+const firefox = `navigator.userAgent.toLowerCase().indexOf('firefox') > -1`;
+const safari = '/^((?!chrome|android).)*safari/i.test(navigator.userAgent)';
+
 const skipTests = {
   files: [
     'packages/vaadin-upload/test/adding-files.test.js',
@@ -36,34 +40,34 @@ const skipTests = {
     `it('should have matching scrollHeight'`
   ],
   to: [
-    `const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+    `const isFirefox = ${firefox};
   (isFirefox ? describe.skip : describe)('with add button'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
     (isSafari ? it.skip : it)('should toggle on input click on touch devices'`,
     `(isSafari ? it.skip : it)('should not clear on input click on touch devices'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
     (isSafari ? it.skip : it)('should select the input field text when navigating down'`,
     `(isSafari ? it.skip : it)('should select the input field text when navigating up'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
   (isSafari ? it.skip : it)('should detect touch support'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
   (isIOS || isSafari ? it.skip : it)('should open context menu below button'`,
     '<button on-click="_showMenu" id="button" style="margin: 20px">Show context menu</button>',
-    `const isChrome = window.chrome || /HeadlessChrome/.test(navigator.userAgent);
+    `const isChrome = ${chrome};
     (isChrome ? describe : describe.skip)('scrolling'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
   (isSafari ? it.skip : it)('should close submenu on mobile when selecting an item in the nested one'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
         (isFirefox || isSafari ? it.skip : it)(\`should apply \${fmt} formatting to the selected text on click\``,
     `(isFirefox ? describe.skip : describe)('image'`,
     `new Touch({ identifier: 1, target: window });`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
     (isSafari ? it.skip : it)('should set checked on touchend'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
     (isSafari ? it.skip : it)('should not set checked on touchend when disabled'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
     (isSafari ? it.skip : it)('should fire on touchend'`,
-    `const isSafari = /Safari/i.test(navigator.userAgent);
+    `const isSafari = ${safari};
       (isSafari ? it.skip : it)('should not change height'`,
     `(isSafari ? it.skip : it)('should have matching scrollHeight'`
   ]


### PR DESCRIPTION
The old regexp used for Safari was also affecting Chrome, updated the script to use the correct one.